### PR TITLE
2 enhancements to the script

### DIFF
--- a/jira/prepare-commit-msg
+++ b/jira/prepare-commit-msg
@@ -1,6 +1,5 @@
 #!/usr/bin/php
 <?php
-
 # Git Prepare Commit Message Hook Script
 #
 # Location: <repository>/.git/hooks/prepare-commit-msg
@@ -18,15 +17,13 @@
 
 $messageFile = $argv[1];
 $message = file_get_contents($messageFile);
-
 $messageJiraPattern = '/^([A-Z]{1,32}-[0-9]{1,32})\ /';
-preg_match($messagePivotalPattern, $message, $matches);
-$messageJiraId = (isset($matches[1])) ? $matches[1] : null;
-if ($messageJiraId === null) {
+if (!preg_match($messageJiraPattern, $message)) {
     $currentBranchName = exec('git rev-parse --abbrev-ref HEAD');
     $branchJiraPattern = '/^([a-zA-Z]{1,32}-[0-9]{1,32})[-_]?/';
     preg_match($branchJiraPattern, $currentBranchName, $matches);
-    $branchJiraId = (isset($matches[1])) ? $matches[1] : null;
+    $envId = getenv("JIRA_TICKET");
+    $branchJiraId = (isset($matches[1])) ? $matches[1] : $envId;
     if ($branchJiraId !== null) {
         $message = sprintf('%s %s', strtoupper($branchJiraId), $message);
         file_put_contents($messageFile, $message);


### PR DESCRIPTION
1. If a Jira ticket number is already in the commit message, don't add it a second time. This did not work well in the previous version.
2. If the JIRA_TICKET environment variable is set, use that when a ticket branch is not available. So you can use `export JIRA_TICKET="EXAMPLE-123"` before you start working on a ticket and use that instead of a branch name.

I have an alias for that in my ~/.bash_profile that looks like this:

``` bash
jiraTicket() {
   export JIRA_TICKET="$1"
}
alias j=jiraTicket
```

So then I can type `j EXAMPLE-123` before starting work.
